### PR TITLE
single.php - Next/Previous links only when exist.

### DIFF
--- a/single.php
+++ b/single.php
@@ -24,8 +24,24 @@ get_header(); ?>
 		
 		<nav id="nav-single" class="pager">
 			<h3 class="assistive-text"><?php _e( 'Post navigation', 'the-bootstrap' ); ?></h3>
-			<span class="next"><?php next_post_link( '%link', sprintf( '%1$s <span class="meta-nav">&rarr;</span>', __( 'Next Post', 'the-bootstrap' ) ) ); ?></span>
-			<span class="previous"><?php previous_post_link( '%link', sprintf( '<span class="meta-nav">&larr;</span> %1$s', __( 'Previous Post', 'the-bootstrap' ) ) ); ?></span>
+			<?php 
+				$prev_post = get_previous_post();
+				if (!empty($prev_post)) {
+			?>
+					<a class="pull-left" href="<?php echo get_permalink( $prev_post->ID ); ?>" rel="prev">
+						<span class="meta-nav">&larr;</span>
+						<?php echo __( 'Previous Post', 'the-bootstrap' ) ?>
+					</a>
+				<?php } ?>
+			<?php 
+				$next_post = get_next_post();
+				if (!empty($next_post)) {
+			?>
+					<a class="pull-right" href="<?php echo get_permalink( $next_post->ID ); ?>" rel="next">
+						<?php echo __( 'Next Post', 'the-bootstrap' ) ?>
+						<span class="meta-nav">&rarr;</span>
+					</a>
+				<?php } ?>	
 		</nav><!-- #nav-single -->
 		
 		<?php tha_content_bottom(); ?>


### PR DESCRIPTION
-- Problems --
Next/Previous post links rendered with no link or text if there was no next/previous post and with a doubled outer border around the link that existed if one was missing. 

Functions previous_post_link(), next_post_link() echo the link (don't return a value--that took an hour or two to discover), so are unsuitable for retrieving the link and testing the value.

-- Changes --
Used get_previous_post()/get_next_post() to detect if prev/next post exists. Only include prev/next links if corresponding post exists.

Used get_permalink() to get href to avoid issues with previous_post_link() and next_post_link(). Also makes the HTML easier to read and modify IMO.

Simplified container structure to avoid double border.

Put Previous on the left, Next on the right. Most languages are left-to-right. In LTR languages, previous "page" is on the left. This agrees with the original arrow directions which pointed left for Previous and right for Next.

Moved right-arrow on next to right edge of link. (Now <-Previous  Next-> instead of <-Previous ->Next.)

Added pull-left, pull-right to links. (Looks better, IMO.)

-- Note to Konstantin --
For my child theme, I plan to generate prev/next in a function called from single.php. I want to show the post title instead of "Next"/"Previous" and need to support "cousins" navigation (move to prev/next under a common ancestor category--similar to what the next_page_not_next_post plugin does).

My first step will be to replicate the existing behavior in a function. I can update code here with that (so child themes can override the function in functions.php instead of copying and modifying single.php). Let me know if you want me to update git when I have that working. Also, let me know if you have a preference for where the function goes (functions.php, somewhere in ./inc, etc.).

(PS: This theme is the only reason I have a user id on git. ^_^ )
