### PR TITLE
Get Bootstrap css and js from child theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -225,7 +225,7 @@ function the_bootstrap_register_scripts_styles() {
 		/**
 		 *  Determine correct uri for bootstrap css and js based on options
 		 */
-		if ( 'child-bootstrap'== the_bootstrap_options()->bootswatch ) {
+		if ( 'child-bootstrap' == the_bootstrap_options()->bootswatch ) {
 			$dir_uri = get_stylesheet_directory_uri();
 		} else {
 			$dir_uri = get_template_directory_uri();

--- a/functions.php
+++ b/functions.php
@@ -259,7 +259,7 @@ function the_bootstrap_register_scripts_styles() {
 				break;
 
 			case 'child-bootstrap':
-				wp_register_style( 'twitter-bootstrap', $dir_uri . "/css/bootstrap{$suffix}.css", array(), '2.1.1' );
+				wp_register_style( 'child-bootstrap', $dir_uri . "/css/bootstrap{$suffix}.css", array(), '2.1.1' );
 				break;
 				
 			case 'amelia-bootstrap':

--- a/functions.php
+++ b/functions.php
@@ -223,11 +223,20 @@ function the_bootstrap_register_scripts_styles() {
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) AND SCRIPT_DEBUG ) ? '' : '.min';
 
 		/**
+		 *  Determine correct uri for bootstrap css and js based on options
+		 */
+		if ( 'child-bootstrap'== the_bootstrap_options()->bootswatch ) {
+			$dir_uri = get_stylesheet_directory_uri();
+		} else {
+			$dir_uri = get_template_directory_uri();
+		} 
+		
+		/**
 		 * Scripts
 		 */
 		wp_register_script(
 			'twitter-bootstrap',
-			get_template_directory_uri() . "/js/bootstrap{$suffix}.js",
+			$dir_uri . "/js/bootstrap{$suffix}.js",
 			array('jquery'),
 			'2.1.1',
 			true
@@ -235,7 +244,7 @@ function the_bootstrap_register_scripts_styles() {
 
 		wp_register_script(
 			'the-bootstrap',
-			get_template_directory_uri() . "/js/the-bootstrap{$suffix}.js",
+			get_template_directory_uri() . "/js/the-bootstrap{$suffix}.js",  // theme specific, pull from parent
 			array('twitter-bootstrap'),
 			$theme_version,
 			true
@@ -246,75 +255,79 @@ function the_bootstrap_register_scripts_styles() {
 		 */
 		switch ( the_bootstrap_options()->bootswatch ) {
 			case 'twitter-bootstrap':
-				wp_register_style( 'twitter-bootstrap', get_template_directory_uri() . "/css/bootstrap{$suffix}.css", array(), '2.1.1' );
+				wp_register_style( 'twitter-bootstrap', $dir_uri . "/css/bootstrap{$suffix}.css", array(), '2.1.1' );
 				break;
 
+			case 'child-bootstrap':
+				wp_register_style( 'twitter-bootstrap', $dir_uri . "/css/bootstrap{$suffix}.css", array(), '2.1.1' );
+				break;
+				
 			case 'amelia-bootstrap':
 				wp_register_style( 'amelia-lobster-font', "$protocol://fonts.googleapis.com/css?family=Lobster", array(), null );
 				wp_register_style( 'amelia-cabin-font', "$protocol://fonts.googleapis.com/css?family=Cabin:400,700", array(), null );
-				wp_register_style( 'amelia-bootstrap', get_template_directory_uri() . "/css/amelia{$suffix}.css", array( 'amelia-lobster-font', 'amelia-cabin-font' ), $bootswatch_version );
+				wp_register_style( 'amelia-bootstrap', $dir_uri . "/css/amelia{$suffix}.css", array( 'amelia-lobster-font', 'amelia-cabin-font' ), $bootswatch_version );
 				break;
 
 			case 'cerulean-bootstrap':
 				wp_register_style( 'cerulean-telex-font', "$protocol://fonts.googleapis.com/css?family=Telex", array(), null );
-				wp_register_style( 'cerulean-bootstrap', get_template_directory_uri() . "/css/cerulean{$suffix}.css", array( 'cerulean-telex-font' ), $bootswatch_version );
+				wp_register_style( 'cerulean-bootstrap', $dir_uri . "/css/cerulean{$suffix}.css", array( 'cerulean-telex-font' ), $bootswatch_version );
 				break;
 
 			case 'cyborg-bootstrap':
 				wp_register_style( 'cyborg-droid-sans-font', "$protocol://fonts.googleapis.com/css?family=Droid+Sans:400,700", array(), null );
-				wp_register_style( 'cyborg-bootstrap', get_template_directory_uri() . "/css/cyborg{$suffix}.css", array( 'cyborg-droid-sans-font' ), $bootswatch_version );
+				wp_register_style( 'cyborg-bootstrap', $dir_uri . "/css/cyborg{$suffix}.css", array( 'cyborg-droid-sans-font' ), $bootswatch_version );
 				break;
 
 			case 'journal-bootstrap':
 				wp_register_style( 'journal-news-cycle-font', "$protocol://fonts.googleapis.com/css?family=News+Cycle:400,700", array(), null );
-				wp_register_style( 'journal-bootstrap', get_template_directory_uri() . "/css/journal{$suffix}.css", array( 'journal-news-cycle-font' ), $bootswatch_version );
+				wp_register_style( 'journal-bootstrap', $dir_uri . "/css/journal{$suffix}.css", array( 'journal-news-cycle-font' ), $bootswatch_version );
 				break;
 
 			case 'readable-bootstrap':
-				wp_register_style( 'readable-bootstrap', get_template_directory_uri() . "/css/readable{$suffix}.css", array(), $bootswatch_version );
+				wp_register_style( 'readable-bootstrap', $dir_uri . "/css/readable{$suffix}.css", array(), $bootswatch_version );
 				break;
 
 			case 'simplex-bootstrap':
 				wp_register_style( 'simplex-josefin-sans-font', "$protocol://fonts.googleapis.com/css?family=Josefin+Sans:300,400,700", array(), null );
-				wp_register_style( 'simplex-bootstrap', get_template_directory_uri() . "/css/simplex{$suffix}.css", array( 'simplex-josefin-sans-font' ), $bootswatch_version );
+				wp_register_style( 'simplex-bootstrap', $dir_uri . "/css/simplex{$suffix}.css", array( 'simplex-josefin-sans-font' ), $bootswatch_version );
 				break;
 
 			case 'slate-bootstrap':
-				wp_register_style( 'slate-bootstrap', get_template_directory_uri() . "/css/slate{$suffix}.css", array(), $bootswatch_version );
+				wp_register_style( 'slate-bootstrap', $dir_uri . "/css/slate{$suffix}.css", array(), $bootswatch_version );
 				break;
 
 			case 'spacelab-bootstrap':
 				wp_register_style( 'spacelab-muli-font', "$protocol://fonts.googleapis.com/css?family=Muli", array(), null );
-				wp_register_style( 'spacelab-bootstrap', get_template_directory_uri() . "/css/spacelab{$suffix}.css", array( 'spacelab-muli-font' ), $bootswatch_version );
+				wp_register_style( 'spacelab-bootstrap', $dir_uri . "/css/spacelab{$suffix}.css", array( 'spacelab-muli-font' ), $bootswatch_version );
 				break;
 
 			case 'spruce-bootstrap':
 				wp_register_style( 'spruce-josefin-slab-font', "$protocol://fonts.googleapis.com/css?family=Josefin+Slab:400,700", array(), null );
-				wp_register_style( 'spruce-bootstrap', get_template_directory_uri() . "/css/spruce{$suffix}.css", array( 'spruce-josefin-slab-font' ), $bootswatch_version );
+				wp_register_style( 'spruce-bootstrap', $dir_uri . "/css/spruce{$suffix}.css", array( 'spruce-josefin-slab-font' ), $bootswatch_version );
 				break;
 
 			case 'superhero-bootstrap':
 				wp_register_style( 'superhero-oswald-font', "$protocol://fonts.googleapis.com/css?family=Oswald", array(), null );
 				wp_register_style( 'superhero-noticia-text-font', "$protocol://fonts.googleapis.com/css?family=Noticia+Text", array(), null );
-				wp_register_style( 'superhero-bootstrap', get_template_directory_uri() . "/css/superhero{$suffix}.css", array( 'superhero-oswald-font', 'superhero-noticia-text-font' ), $bootswatch_version );
+				wp_register_style( 'superhero-bootstrap', $dir_uri . "/css/superhero{$suffix}.css", array( 'superhero-oswald-font', 'superhero-noticia-text-font' ), $bootswatch_version );
 				break;
 
 			case 'united-bootstrap':
 				wp_register_style( 'united-ubuntu-font', "$protocol://fonts.googleapis.com/css?family=Ubuntu", array(), null );
-				wp_register_style( 'united-bootstrap', get_template_directory_uri() . "/css/united{$suffix}.css", array( 'united-ubuntu-font' ), $bootswatch_version );
+				wp_register_style( 'united-bootstrap', $dir_uri . "/css/united{$suffix}.css", array( 'united-ubuntu-font' ), $bootswatch_version );
 				break;
 		}
 
 		wp_enqueue_style(
 			'twitter-bootstrap-responsive',
-			get_template_directory_uri() . "/css/bootstrap-responsive{$suffix}.css",
+			$dir_uri . "/css/bootstrap-responsive{$suffix}.css",
 			array( the_bootstrap_options()->bootswatch ),
 			'2.1.1'
 		);
 
 		wp_register_style(
 			'the-bootstrap',
-			get_template_directory_uri() . "/style{$suffix}.css",
+			get_template_directory_uri() . "/style{$suffix}.css",  // theme specific, get from parent
 			array( the_bootstrap_options()->bootswatch, 'twitter-bootstrap-responsive' ),
 			$theme_version
 		);

--- a/inc/theme-customizer.php
+++ b/inc/theme-customizer.php
@@ -50,6 +50,7 @@ function the_bootstrap_customize_register( $wp_customize ) {
 		'type'		=>	'radio',
 		'choices'	=>	array(
 			'twitter-bootstrap'   => 'Twitter',
+			'child-bootstrap'     => 'Child Theme Bootstrap',
 			'amelia-bootstrap'    => 'Amelia',
 			'cerulean-bootstrap'  => 'Cerulean',
 			'cyborg-bootstrap'    => 'Cyborg',


### PR DESCRIPTION
I've been getting a better handle on github and have rebuilt my repo. Meanwhile, here is a change that replaces a pair of earlier changes I submitted and you closed. Based on your comment at the time ("the theme customizer is the future") and the fact that I'd made the change in theme options, I'm resubmitting with the option added to the theme customizer instead.

I tested this change on localhost and viewed the page and page source to verify that files are pulling from the right place for Twitter, Child Theme Bootstrap options. I also viewed the page only to verify that Amelia, Journal, and Spruce were working as expected (spot check of Bootswatch themes). Note that Child Theme Bootstrap looks wrong in the customizer, but looks right on the page.

Image below shows what the theme customizer looks like after the change. After the image is the description from the first commit, which explains why I think allowing child themes to have custom Bootstrap files is a good idea. The other two commits are fixes to this branch applied during code review or testing.
![CustomizerChange](https://f.cloud.github.com/assets/2394875/347948/2edf2082-9f0d-11e2-9461-d780c7d00e4e.jpg)

Adds an option to the theme customizer (inc/theme-customizer.php) and
corresponding changes to functions.php that allows a person using a
child theme to choose to pull Bootstrap (css and js) from the child
theme's css and js directories.

This change allows people using the-bootstrap to compile a custom
version of Bootstrap css files with LESS without overwriting the parent
theme's css files and avoid overriding default colors, fonts, etc. in
their child theme's styles. This can significant simplify child theme
customization and reduce the total size of CSS to load. Tools like
bootswatchr.com make custom Bootstrap easy even for people who aren't
comfortable with LESS tools.

This change also allows theme users to update Bootstrap out of sync with
the parent theme without overwriting the parent's copies of Bootstrap
files. This makes it easier to identify if problems are caused by
Bootstrap customization (now isolated to the child) or are in
the-bootstrap without custom Bootstrap files.
